### PR TITLE
Add ip check to server logs

### DIFF
--- a/server.py
+++ b/server.py
@@ -24,7 +24,15 @@ class CarbonDateServer(tornado.web.RequestHandler):
             return
 
         logger = logging.getLogger('server')
-        logger.log(45, 'Get request from %s' % (self.request.remote_ip))
+
+        realIP = self.request.remote_ip
+        print(self.request.headers)
+        if self.request.headers.get("X-Real-IP"):
+            realIP = self.request.headers.get("X-Real-IP")
+        if self.request.headers.get("X-Forwarded-For"):
+            realIP = self.request.headers.get("X-Forwarded-For")
+
+        logger.log(45, 'Get request from %s' % (realIP))
         logger.log(45, 'URI Requested: %s' % (url))
         fileConfig = open("config", "r")
         config = fileConfig.read()

--- a/server.py
+++ b/server.py
@@ -26,7 +26,6 @@ class CarbonDateServer(tornado.web.RequestHandler):
         logger = logging.getLogger('server')
 
         realIP = self.request.remote_ip
-        print(self.request.headers)
         if self.request.headers.get("X-Real-IP"):
             realIP = self.request.headers.get("X-Real-IP")
         if self.request.headers.get("X-Forwarded-For"):


### PR DESCRIPTION
Adds an ip check for a request's headers. Checks for 'X-Real-IP' or 'X-Forwarded-For'.