### PR TITLE
Bitly JSON exception handling

### DIFF
--- a/modules/cdGetBitly.py
+++ b/modules/cdGetBitly.py
@@ -131,7 +131,3 @@ def getBitly(url, outputArray, indexOfOutputArray, verbose=False, **kwargs):
         kwargs['displayArray'][indexOfOutputArray] = ""
         logging.debug("Done Bitly")
         return ""
-
-
-def checkFailure(jsonData):
-    print()

--- a/modules/cdGetBitly.py
+++ b/modules/cdGetBitly.py
@@ -54,7 +54,10 @@ def GetBitlyJson(URL):
         if(page.find(b'"error": "NOT_FOUND"') != -1):
             break
 
-        jsonData = json.loads(page.decode())
+        try:
+            jsonData = json.loads(page.decode())
+        except:
+            continue
 
         if(jsonData['status_code'] == 403):
             continue
@@ -128,3 +131,7 @@ def getBitly(url, outputArray, indexOfOutputArray, verbose=False, **kwargs):
         kwargs['displayArray'][indexOfOutputArray] = ""
         logging.debug("Done Bitly")
         return ""
+
+
+def checkFailure(jsonData):
+    print()

--- a/modules/cdGetBitly.py
+++ b/modules/cdGetBitly.py
@@ -57,6 +57,7 @@ def GetBitlyJson(URL):
         try:
             jsonData = json.loads(page.decode())
         except:
+            logging.debug('Failed to load Bitly json')
             continue
 
         if(jsonData['status_code'] == 403):


### PR DESCRIPTION
Server logs were getting an exception when loading Bitly JSON which linked back to no exception handling. This pull adds exception handling to the response.