### PR TITLE
Command line refactor removing sub process calls in main.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then you may open your browser to: `http://localhost:8888/`
 
 To run locally use:
 ```
-$ docker run --rm -it -p 8888:8888 oduwsdl/carbondate ./main.py -l search {URI-R}
+$ docker run --rm -it -p 8888:8888 oduwsdl/carbondate ./main.py -l {URI-R}
 ```
 
 ### Running without Docker
@@ -46,7 +46,7 @@ Then you may open your browser to: `http://localhost:8888/`
 To run it as a local script:
 
 ```
-$ ./main.py -l search {URI-R}
+$ ./main.py -l {URI-R}
 ```
 
 ### Environment variables
@@ -56,7 +56,7 @@ For Bitly, the environment key is `CD_Bitly_token`. For Bing, the environment ke
 Environment variables can be passed into docker using the `-e` or `--env` arguments before executing the Carbon Date application like so:
 
 ```
-$ docker run -e "CD_Bitly_token=foo" -e "CD_Bing_key=bar" -it --rm oduwsdl/carbondate ./main.py -l search http://www.cs.odu.edu/
+$ docker run -e "CD_Bitly_token=foo" -e "CD_Bing_key=bar" -it --rm oduwsdl/carbondate ./main.py -l http://www.cs.odu.edu/
 ```
 
 ### Disabling modules
@@ -65,7 +65,7 @@ CarbonDate provides the option of preventing searching for specified modules in 
 For example, if a user wants to disable backlinks and google modules the user can add the `-e` argument after a URI-R is specified like so:
 
 ```
-./main.py -l search "https://www.cs.odu.edu/" -e cdGetBacklinks cdGetGoogle
+./main.py -l "https://www.cs.odu.edu/" -e cdGetBacklinks cdGetGoogle
 ```
 
 A complete list of all the modules a user can disable is as follows:

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ $ docker run -e "CD_Bitly_token=foo" -e "CD_Bing_key=bar" -it --rm oduwsdl/carbo
 
 ### Disabling modules
 
-CarbonDate provides the option of preventing searching for specified modules in the local version.
+CarbonDate provides the option of preventing searching for specified modules.
 For example, if a user wants to disable backlinks and google modules the user can add the `-e` argument after a URI-R is specified like so:
 
 ```
-./main.py -l "https://www.cs.odu.edu/" -e cdGetBacklinks cdGetGoogle
+$ ./main.py -l "https://www.cs.odu.edu/" -e cdGetBacklinks cdGetGoogle
 ```
 
 A complete list of all the modules a user can disable is as follows:

--- a/core.py
+++ b/core.py
@@ -1,6 +1,3 @@
-__author__ = "Neo"
-__copyright__ = "Copyleft 2016, United States"
-
 import os
 import sys
 import datetime
@@ -72,7 +69,12 @@ class ModuleManager():
                 self.entryPoints[modName]["displayName"] = mod[5:]
 
     def getAvailableModules(self):
-        return self.modules
+        print('Available Modules (include system utilities)')
+        print('====================================')
+        for m in self.modules:
+            print(m)
+        print('====================================')
+        print()
 
     def call(self, moduleName, **kwargs):
         if moduleName in self.entryPoints:
@@ -89,7 +91,10 @@ class ModuleManager():
                 'ModuleManager: Error : No such module: %s' % moduleName)
 
     def run(self, args, **kwargs):
-        url = args.url
+        if args.local_uri:
+            url = args.local_uri
+        else:
+            url = kwargs['url']
         # handle character accents
         url = requote_uri(url)
 
@@ -157,40 +162,3 @@ class ModuleManager():
         kwargs['logger'].log(35, r)
 
         return resultDict
-
-
-if __name__ == '__main__':
-    import argparse
-
-    # init argparse
-    parser = argparse.ArgumentParser(
-        description='Core module to load services and perform queries')
-    modOpGroup = parser.add_mutually_exclusive_group()
-    modOpGroup.add_argument('-a', '--all', action="store_true",
-                            help='Load all modules (default)', dest='all')
-    modOpGroup.add_argument(
-        '-m', help='Specify mode, only load given modules ', nargs='+')
-    modOpGroup.add_argument(
-        '-e', help="Exclusive mode, load all modules except the given modules",
-        nargs='+')
-
-    parser.add_argument('-t', '--timeout', type=int,
-                        help='Set timeout for all modules', default=300)
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help='Enable verbose output')
-
-    parser.add_argument('url', help='The url to look up')
-
-    args = parser.parse_args()
-
-    # read system config
-    fileConfig = open("config", "r")
-    config = fileConfig.read()
-    fileConfig.close()
-    cfg = json.loads(config)
-
-    resultDict = {}
-    mod = ModuleManager()
-    mod.loadModule(cfg, args)
-    mod.run(args=args, resultDict=resultDict)
-    os._exit(0)

--- a/core.py
+++ b/core.py
@@ -68,14 +68,6 @@ class ModuleManager():
             else:
                 self.entryPoints[modName]["displayName"] = mod[5:]
 
-    def getAvailableModules(self):
-        print('Available Modules (include system utilities)')
-        print('====================================')
-        for m in self.modules:
-            print(m)
-        print('====================================')
-        print()
-
     def call(self, moduleName, **kwargs):
         if moduleName in self.entryPoints:
             url = kwargs['url']

--- a/local.py
+++ b/local.py
@@ -1,106 +1,20 @@
 #!/usr/bin/env python3
 
 import json
-import time
-import os
-import core
-import argparse
 import logging
 
 
-def cd(modLoader, args):
+def start(args, mod):
+    '''
+    Start local version of Carbon Tool
+    '''
     result = {}
-    # read system config
-    fileConfig = open("config", "r")
-    config = fileConfig.read()
-    fileConfig.close()
-    cfg = json.loads(config)
     loglevel = logging.WARNING
-
-    modLoader.loadModule(cfg, args)
-
-    if args.mode == 'dev':
-        if args.lm:
-            print('Available Modules (include system utilities)')
-            print('====================================')
-            for m in modLoader.getAvailableModules():
-                print(m)
-            print('====================================')
-            print()
-        else:
-            if args.ak is not None:
-                cfg[args.ak[0]] = args.ak[1]
-                print("\"%s\" is now set to \"%s\"" %
-                      (args.ak[0], cfg[args.ak[0]]))
-                with open('config', 'w') as f:
-                    json.dump(cfg, f, sort_keys=True,
-                              indent=4, separators=(',', ': '))
-            if args.rk is not None:
-                try:
-                    cfg.pop(args.rk)
-                    with open('config', 'w') as f:
-                        json.dump(cfg, f, sort_keys=True,
-                                  indent=4, separators=(',', ': '))
-                except Exception as e:
-                    print('local.py: No such key: %s' % e)
-            if args.lk:
-                print(json.dumps(cfg, sort_keys=True,
-                                 indent=4, separators=(',', ': ')))
-    elif args.mode == 'search':
-        if args.verbose:
-            loglevel = logging.DEBUG
-        logging.basicConfig(level=loglevel, format='%(message)s')
-        logger = logging.getLogger('local')
-        result['self'] = ""
-        modLoader.run(args=args, resultDict=result, logger=logger)
-        os._exit(0)
-
-
-if __name__ == '__main__':
-
-    # init argparse
-    parser = argparse.ArgumentParser(
-        description='Local version of Carbon Date Tool')
-    sub_parsers = parser.add_subparsers(dest='mode', help='Working mode')
-    # main search service
-    search_parser = sub_parsers.add_parser(
-        'search', help='Search (normal) mode of carbon tool')
-    modOpGroup = search_parser.add_mutually_exclusive_group()
-    modOpGroup.add_argument('-a', '--all', action="store_true",
-                            help='Load all modules (default)', dest='all')
-    modOpGroup.add_argument(
-        '-m', metavar='MODULE', help='Specify mode, only load given modules ',
-        nargs='+')
-    modOpGroup.add_argument(
-        '-e', metavar='MODULE', help="Exclusive mode, load all modules except \
-        the given modules", nargs='+')
-
-    search_parser.add_argument('url', help='The url to look up')
-
-    search_parser.add_argument(
-        '-t', '--timeout', type=int, help='Set timeout for all modules',
-        default=300)
-    search_parser.add_argument(
-        '-v', '--verbose', action='store_true', help='Enable verbose output')
-
-    # sub command parser for dev mod
-
-    dev_parser = sub_parsers.add_parser(
-        'dev', help='Dev mode of carbon tool, for system configuration')
-    dev_parser.add_argument('-lm', action="store_true",
-                            help="List all the module available in the system")
-    dev_parser.add_argument('-ak', metavar=('KEY', 'VALUE'), nargs=2,
-                            help='Add/update api key, system configuration, \
-                            etc')
-    dev_parser.add_argument('-rk', metavar='KEY',
-                            help='Remove configuration key pair')
-    dev_parser.add_argument('-lk', action='store_true',
-                            help='List all the configuration key-value pair \
-                            (Environment value will overwrite certain \
-                            value during runtime)')
-
-    args = parser.parse_args()
-
-    mod = core.ModuleManager()
-    time.strptime("1995-01-01T12:00:00", '%Y-%m-%dT%H:%M:%S')
-    cd(mod, args)
+    if args.verbose:
+        loglevel = logging.DEBUG
+    logging.basicConfig(level=loglevel, format='%(message)s')
+    logger = logging.getLogger('local')
+    result['self'] = ""
+    results = mod.run(args=args, resultDict=result,
+                      logger=logger)
+    print(json.dumps(results, indent=4))

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import argparse
-import os
-import sys
-import shlex
+import server
+import local
+import core
+import json
+import time
 
 logo = ('''
  _____       ___   _____    _____   _____   __   _   _____       ___   _____   _____
@@ -20,26 +22,55 @@ def parserinit():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=logo + 'Integrated interface for Carbon Date Tool',
-        epilog="For more help about running locally, type main.py -lh")
-    modeGroup = parser.add_mutually_exclusive_group(required=True)
-    modeGroup.add_argument('-s', '--server', action="store_true",
-                           help="Launch server of Carbon Date Tool")
-    modeGroup.add_argument('-l', '--local', action="store_true",
-                           help="Run Carbon Date Tool as a local application")
-    modeGroup.add_argument('-lh', action='store_true',
-                           help='Manual of running locally')
+        epilog='For more help, type main.py -h')
+    mode_group = parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument('-s', '--server', action='store_true',
+                            help='Launch server version of Carbon Date Tool')
+    mode_group.add_argument('-l', '--local', metavar='{URI}',
+                            help='Run Carbon Date Tool as a local application.'
+                            ' Takes a URI as a parameter',
+                            dest="local_uri")
+    parser.add_argument('-t', '--timeout', type=int,
+                        help='Set timeout for all modules in seconds',
+                        default=300)
+    parser.add_argument('--list-mods', action='store_true',
+                        help='List all avaiable modules')
+    parser.add_argument(
+        '-v', '--verbose', action='store_true', help='Enable verbose output')
+    modOpGroup = parser.add_mutually_exclusive_group()
+    modOpGroup.add_argument('-a', '--all', action="store_true",
+                            help='Load all modules (default)', dest='all')
+    modOpGroup.add_argument(
+        '-m', metavar='MODULE', help='Specify mode, only load given modules ',
+        nargs='+')
+    modOpGroup.add_argument(
+        '-e', metavar='MODULE', help="Exclusive mode, load all modules except \
+        the given modules", nargs='+')
     return parser
 
 
 if __name__ == '__main__':
+    '''
+    If time.strptime is used before starting the threads, then no exception
+    is raised (the issue may thus come from strptime.py not being imported in
+    a thread safe manner). -- http://bugs.python.org/issue7980
+    '''
+    time.strptime("1995-01-01T12:00:00", '%Y-%m-%dT%H:%M:%S')
     parser = parserinit()
     args, unknown = parser.parse_known_args()
+
+    # read system config
+    fileConfig = open("config", "r")
+    config = fileConfig.read()
+    fileConfig.close()
+    cfg = json.loads(config)
+    # setup modules to load
+    mod = core.ModuleManager()
+    mod.loadModule(cfg, args)
+
+    if args.list_mods:
+        mod.getAvailableModules()
     if args.server:
-        os.system('./server.py')
-    elif args.local:
-        arg_str = ""
-        for a in sys.argv[2:]:
-            arg_str += (' ' + shlex.quote(a))
-        os.system('./local.py%s' % (arg_str))
-    elif args.lh:
-        os.system('./local.py -h')
+        server.start(args, cfg, mod)
+    elif args.local_uri:
+        local.start(args, mod)

--- a/main.py
+++ b/main.py
@@ -24,6 +24,8 @@ def parserinit():
         description=logo + 'Integrated interface for Carbon Date Tool',
         epilog='For more help, type main.py -h')
     mode_group = parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument('--list-mods', action='store_true',
+                            help='List all avaiable modules')
     mode_group.add_argument('-s', '--server', action='store_true',
                             help='Launch server version of Carbon Date Tool')
     mode_group.add_argument('-l', '--local', metavar='{URI}',
@@ -33,8 +35,6 @@ def parserinit():
     parser.add_argument('-t', '--timeout', type=int,
                         help='Set timeout for all modules in seconds',
                         default=300)
-    parser.add_argument('--list-mods', action='store_true',
-                        help='List all avaiable modules')
     parser.add_argument(
         '-v', '--verbose', action='store_true', help='Enable verbose output')
     modOpGroup = parser.add_mutually_exclusive_group()
@@ -69,8 +69,12 @@ if __name__ == '__main__':
     mod.loadModule(cfg, args)
 
     if args.list_mods:
-        mod.getAvailableModules()
-    if args.server:
+        print('Available Modules (include system utilities)')
+        print('====================================')
+        for m in mod.modules:
+            print(m)
+        print('====================================')
+    elif args.server:
         server.start(args, cfg, mod)
     elif args.local_uri:
         local.start(args, mod)

--- a/server.py
+++ b/server.py
@@ -1,20 +1,29 @@
 #!/usr/bin/env python3
 import json
-import time
 import os
 from collections import OrderedDict
 
 import tornado.web
 import tornado.ioloop
-import core
-import argparse
 import logging
 from multiprocessing.pool import ThreadPool
 
 _workers = ThreadPool(50)
+# initialize logger
+logging.basicConfig(level=int(os.environ.get("LOGLV", logging.ERROR)),
+                    format='%(asctime)s [%(levelname)s]%(funcName)s : '
+                    '%(message)s',
+                    handlers=[logging.FileHandler("logs/carbonServer.log"),
+                              logging.StreamHandler()])
+logger = logging.getLogger('server')
+logging.addLevelName(45, "Server")
 
 
 class CarbonDateServer(tornado.web.RequestHandler):
+    def initialize(self, args, modLoader):
+        self.args = args
+        self.modLoader = modLoader
+
     @tornado.web.asynchronous
     def get(self, req):
         try:
@@ -33,28 +42,11 @@ class CarbonDateServer(tornado.web.RequestHandler):
 
         logger.log(45, 'Get request from %s' % (realIP))
         logger.log(45, 'URI Requested: %s' % (url))
-        fileConfig = open("config", "r")
-        config = fileConfig.read()
-        fileConfig.close()
-        cfg = json.loads(config)
-
-        parser = argparse.ArgumentParser(
-            description='server version of Carbon Date Tool')
-        parser.add_argument('-a', '--all', action="store_true")
-        parser.add_argument('-e', metavar='MODULE')
-        parser.add_argument('url', help='The url to look up')
-        parser.add_argument('-t', '--timeout', type=int,
-                            help='Set timeout for all modules', default=300)
-        parser.add_argument('-v', '--verbose',
-                            action='store_true', help='Enable verbose output')
-
-        args = parser.parse_args(['-a', url])
 
         result = {}
-        modLoader = core.ModuleManager()
-        modLoader.loadModule(cfg, args)
-        self.run_background(modLoader.run, self.on_complete,
-                            args=args, resultDict=result, logger=logger)
+        self.run_background(self.modLoader.run, self.on_complete,
+                            args=self.args, resultDict=result, logger=logger,
+                            url=url)
 
     def on_complete(self, res):
         resultDict = {}
@@ -79,45 +71,21 @@ class CarbonDateServer(tornado.web.RequestHandler):
         _workers.apply_async(func, args, kwargs, _callback)
 
 
-if __name__ == '__main__':
+def start(args, config, mod):
     '''
-    If time.strptime is used before starting the threads, then no exception
-    is raised (the issue may thus come from strptime.py not being imported in
-    a thread safe manner). -- http://bugs.python.org/issue7980
+    Start server version of Carbon Tool
     '''
-    time.strptime("1995-01-01T12:00:00", '%Y-%m-%dT%H:%M:%S')
-
-    fileConfig = open("config", "r")
-    config = fileConfig.read()
-    fileConfig.close()
-    jsonFile = json.loads(config)
-    ServerIP = jsonFile["ServerIP"]
-    ServerPort = jsonFile["ServerPort"]
-
-    ip_env = os.getenv('CD_Server_IP')
+    ServerPort = config["ServerPort"]
     port_env = os.getenv('CD_Server_port')
-    if ip_env is not None:
-        logging.warning(
-            'Server.py: Server IP detected in environment variable, overwite \
-             local config values.')
-        ServerIP = int(ip_env)
     if port_env is not None:
         logging.warning(
             'Server.py: Server Port number detected in environment variable, \
             overwite local config values.')
         ServerPort = int(port_env)
 
-    # initialize logger
-    logging.basicConfig(level=int(os.environ.get("LOGLV", logging.ERROR)),
-                        format='%(asctime)s [%(levelname)s]%(funcName)s : '
-                        '%(message)s',
-                        handlers=[logging.FileHandler("logs/carbonServer.log"),
-                                  logging.StreamHandler()])
-    logger = logging.getLogger('server')
-    logging.addLevelName(45, "Server")
     # initialize server
     app = tornado.web.Application([
-        (r"/cd/(.*)", CarbonDateServer),
+        (r"/cd/(.*)", CarbonDateServer, dict(args=args, modLoader=mod)),
         (r'/(.*)', tornado.web.StaticFileHandler,
          {'path': 'docs', "default_filename": "index.html"})
     ])


### PR DESCRIPTION
Related to #18, #15.

Arguments are now generalized to address both server and local
version. Either server `-s` or local `-l` are now required arguments, 
where the local version now is executed using `$ main.py -l {URI}` 
instead of `$ main.py -l search {URI}`.
Generalized duplicate code in main.py, such as reading the
config file and instantiating the module reader. 

Server can now exclude modules as mentioned in #15.
